### PR TITLE
Take the category into account in access log handler only if non null

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/accesslog/AccessLogHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/accesslog/AccessLogHandler.java
@@ -198,7 +198,7 @@ public class AccessLogHandler implements HttpHandler {
 
         @Override
         public HttpHandler wrap(HttpHandler handler) {
-            return new AccessLogHandler(handler, new JBossLoggingAccessLogReceiver(category), format, Wrapper.class.getClassLoader());
+            return new AccessLogHandler(handler, category == null ? new JBossLoggingAccessLogReceiver() : new JBossLoggingAccessLogReceiver(category), format, Wrapper.class.getClassLoader());
         }
     }
 }


### PR DESCRIPTION
Fixes issue reported here: https://groups.google.com/d/msg/quarkus-dev/2jFpwMt4QaI/aiSxjErFEwAJ

/cc @stuartwdouglas 

We will need a new release of Quarkus HTTP once this is in.