### PR TITLE
websocketExtensionHandler may not always be present for it to be removed

### DIFF
--- a/vertx/src/main/java/io/undertow/vertx/VertxHttpExchange.java
+++ b/vertx/src/main/java/io/undertow/vertx/VertxHttpExchange.java
@@ -19,6 +19,7 @@ import org.jboss.logging.Logger;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelHandler;
 import io.netty.util.concurrent.EventExecutor;
 import io.undertow.httpcore.BufferAllocator;
 import io.undertow.httpcore.ConnectionSSLSessionInfo;
@@ -202,11 +203,14 @@ public class VertxHttpExchange extends HttpExchangeBase implements HttpExchange,
             }
         });
         if (request.headers().contains(HttpHeaderNames.UPGRADE)) {
-            //we allways remove the websocket handler
+            upgradeRequest = true;
+            //we always remove the websocket handler (if it's present)
             ConnectionBase connection = (ConnectionBase) request.connection();
             ChannelHandlerContext c = connection.channelHandlerContext();
-            upgradeRequest = true;
-            c.pipeline().remove("websocketExtensionHandler");
+            final ChannelHandler websocketChannelHandler = c.pipeline().get("websocketExtensionHandler");
+            if (websocketChannelHandler != null) {
+                c.pipeline().remove(websocketChannelHandler);
+            }
         } else {
             upgradeRequest = false;
         }


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/issues/9481 shows a case where `VertxHttpExchange` tries to remove the `websocketExtensionHandler`. The vertx core conditionally registers[1] this `websocketExtensionHandler`, so it may not always be present. In this specific case, it appears that the `websocketExtensionHandler` isn't being added because the `HttpServerConnection` isn't of type `Http1xServerConnection` (and instead is a `io.vertx.core.http.impl.Http2ServerConnection`) [2].

The commit in this PR adds a check before triggering the removal of that handler.

[1] https://github.com/eclipse-vertx/vert.x/blob/3.9/src/main/java/io/vertx/core/http/impl/HttpHandlers.java#L62
[2] https://github.com/eclipse-vertx/vert.x/blob/3.9/src/main/java/io/vertx/core/http/impl/HttpHandlers.java#L66