### PR TITLE
Prevent NPE when remote/local address returned by the HttpServerRequest is null

### DIFF
--- a/vertx/src/main/java/io/undertow/vertx/VertxHttpExchange.java
+++ b/vertx/src/main/java/io/undertow/vertx/VertxHttpExchange.java
@@ -372,12 +372,18 @@ public class VertxHttpExchange extends HttpExchangeBase implements HttpExchange,
     @Override
     public InetSocketAddress getDestinationAddress() {
         SocketAddress socketAddress = request.localAddress();
+        if (socketAddress == null) {
+            return null;
+        }
         return new InetSocketAddress(socketAddress.host(), socketAddress.port());
     }
 
     @Override
     public InetSocketAddress getSourceAddress() {
         SocketAddress socketAddress = request.remoteAddress();
+        if (socketAddress == null) {
+            return null;
+        }
         return new InetSocketAddress(socketAddress.host(), socketAddress.port());
     }
 


### PR DESCRIPTION
Should prevent the NPE noted in https://github.com/quarkusio/quarkus/issues/9807.

The javadoc of `HttpServerRequest` (of vertx-core) states that the returned value can be null for both `remoteAddress()` and `localAddress()` https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/http/HttpServerRequest.java#L168. The commit here adds a check to prevent any NPEs when the request returns null.