### PR TITLE
UNDERTOW-1581: Fix RoutingHandler allMethodsMatcher validation

### DIFF
--- a/core/src/main/java/io/undertow/server/RoutingHandler.java
+++ b/core/src/main/java/io/undertow/server/RoutingHandler.java
@@ -120,7 +120,7 @@ public class RoutingHandler implements HttpHandler {
         if (res == null) {
             matcher.add(template, res = new RoutingMatch());
         }
-        if (allMethodsMatcher.get(template) == null) {
+        if (allMethodsMatcher.match(template) == null) {
             allMethodsMatcher.add(template, res);
         }
         res.defaultHandler = handler;
@@ -152,7 +152,7 @@ public class RoutingHandler implements HttpHandler {
         if (res == null) {
             matcher.add(template, res = new RoutingMatch());
         }
-        if (allMethodsMatcher.get(template) == null) {
+        if (allMethodsMatcher.match(template) == null) {
             allMethodsMatcher.add(template, res);
         }
         res.predicatedHandlers.add(new HandlerHolder(predicate, handler));
@@ -186,7 +186,7 @@ public class RoutingHandler implements HttpHandler {
             // If we use allMethodsMatcher.addAll() we can have duplicate
             // PathTemplates which we want to ignore here so it does not crash.
             for (PathTemplate template : entry.getValue().getPathTemplates()) {
-                if (allMethodsMatcher.get(template.getTemplateString()) == null) {
+                if (allMethodsMatcher.match(template.getTemplateString()) == null) {
                     allMethodsMatcher.add(template, new RoutingMatch());
                 }
             }

--- a/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
@@ -126,6 +126,12 @@ public class RoutingHandlerTestCase {
                         exchange.writeAsync("posted foo");
                     }
                 })
+                .add(HttpMethodNames.POST, "/foo/{baz}", new HttpHandler() {
+                    @Override
+                    public void handleRequest(HttpServerExchange exchange) throws Exception {
+                        exchange.writeAsync("foo-path" + exchange.getQueryParameters().get("bar"));
+                    }
+                })
                 .add(HttpMethodNames.GET, "/foo/{bar}", new HttpHandler() {
                     @Override
                     public void handleRequest(HttpServerExchange exchange) throws Exception {


### PR DESCRIPTION
Updates the allMethodsMatcher to lookup templates using the
match method instead of get in order to normalize the input.

Previously registration would throw an exception when routes
were added for the same path template with different parameter names
despite being equivalent.

From https://github.com/undertow-io/undertow/pull/799