### PR TITLE
Throw an exception in writeBlocking as well

### DIFF
--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -994,6 +994,9 @@ public final class HttpServerExchange extends AbstractAttachable implements Buff
         if (data == null && !last) {
             throw new IllegalArgumentException("cannot call write with a null buffer and last being false");
         }
+        if (getIoThread().inEventLoop()) {
+            throw UndertowMessages.MESSAGES.blockingIoFromIOThread();
+        }
         if (isResponseComplete() || anyAreSet(state, FLAG_LAST_DATA_QUEUED)) {
             if (last && data == null) {
                 return;


### PR DESCRIPTION
Currently this guard is in the streams themselves, but this is safer as
the streams miss close and flush.

The guards in the streams are still nessesary to catch operations that
may block depending on buffer size.