### PR TITLE
Get rid of SingleThreadModel usage

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/ManagedServlet.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/ManagedServlet.java
@@ -27,7 +27,6 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
-import javax.servlet.SingleThreadModel;
 import javax.servlet.UnavailableException;
 
 import io.undertow.server.handlers.form.FormEncodedDataDefinition;
@@ -70,11 +69,7 @@ public class ManagedServlet implements Lifecycle {
     public ManagedServlet(final ServletInfo servletInfo, final ServletContextImpl servletContext) {
         this.servletInfo = servletInfo;
         this.servletContext = servletContext;
-        if (SingleThreadModel.class.isAssignableFrom(servletInfo.getServletClass())) {
-            instanceStrategy = new SingleThreadModelPoolStrategy(servletInfo.getInstanceFactory(), servletInfo, servletContext);
-        } else {
-            instanceStrategy = new DefaultInstanceStrategy(servletInfo.getInstanceFactory(), servletInfo, servletContext);
-        }
+        this.instanceStrategy = new DefaultInstanceStrategy(servletInfo.getInstanceFactory(), servletInfo, servletContext);
         setupMultipart(servletContext);
     }
 
@@ -320,68 +315,5 @@ public class ManagedServlet implements Lifecycle {
             return instanceHandle;
         }
     }
-
-    /**
-     * pooling strategy for single thread model servlet
-     */
-    private static class SingleThreadModelPoolStrategy implements InstanceStrategy {
-
-
-        private final InstanceFactory<? extends Servlet> factory;
-        private final ServletInfo servletInfo;
-        private final ServletContextImpl servletContext;
-
-        private SingleThreadModelPoolStrategy(final InstanceFactory<? extends Servlet> factory, final ServletInfo servletInfo, final ServletContextImpl servletContext) {
-            this.factory = factory;
-            this.servletInfo = servletInfo;
-            this.servletContext = servletContext;
-        }
-
-        @Override
-        public void start() throws ServletException {
-            if(servletInfo.getLoadOnStartup() != null) {
-                //see UNDERTOW-734, make sure init method is called for load on startup
-                getServlet().release();
-            }
-        }
-
-        @Override
-        public void stop() {
-
-        }
-
-        @Override
-        public InstanceHandle<? extends Servlet> getServlet() throws ServletException {
-            final InstanceHandle<? extends Servlet> instanceHandle;
-            final Servlet instance;
-            //TODO: pooling
-            try {
-                instanceHandle = factory.createInstance();
-            } catch (Exception e) {
-                throw UndertowServletMessages.MESSAGES.couldNotInstantiateComponent(servletInfo.getName(), e);
-            }
-            instance = instanceHandle.getInstance();
-            new LifecyleInterceptorInvocation(servletContext.getDeployment().getDeploymentInfo().getLifecycleInterceptors(), servletInfo, instance, new ServletConfigImpl(servletInfo, servletContext)).proceed();
-
-            return new InstanceHandle<Servlet>() {
-                @Override
-                public Servlet getInstance() {
-                    return instance;
-                }
-
-                @Override
-                public void release() {
-                    try {
-                        instance.destroy();
-                    } catch (Throwable t) {
-                        UndertowServletLogger.REQUEST_LOGGER.failedToDestroy(instance, t);
-                    }
-                    instanceHandle.release();
-                }
-            };
-
-        }
-    }
-
 
 }

--- a/servlet/src/test/java/io/undertow/servlet/test/lifecycle/ThirdServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/lifecycle/ThirdServlet.java
@@ -25,14 +25,13 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.SingleThreadModel;
 
 import org.junit.Assert;
 
 /**
  * @author Stuart Douglas
  */
-public class ThirdServlet implements Servlet, SingleThreadModel {
+public class ThirdServlet implements Servlet {
 
     public static volatile boolean init;
 


### PR DESCRIPTION
It has been deprecated with no replacement since Servlet API 2.4 and it
is gone in Servlet API 6.0.