### PR TITLE
Drop .Final suffix

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-parent</artifactId>
-        <version>5.2.3.Final-SNAPSHOT</version>
+        <version>5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-http-core</artifactId>

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-parent</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.2.3-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-http-coverage-report</artifactId>
     <name>Undertow Test Coverage Report</name>

--- a/http-core/pom.xml
+++ b/http-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-parent</artifactId>
-        <version>5.2.3.Final-SNAPSHOT</version>
+        <version>5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-http-http-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>io.quarkus.http</groupId>
     <artifactId>quarkus-http-parent</artifactId>
-    <version>5.2.3.Final-SNAPSHOT</version>
+    <version>5.2.3-SNAPSHOT</version>
 
     <name>Quarkus HTTP</name>
     <description>Quarkus HTTP</description>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-parent</artifactId>
-        <version>5.2.3.Final-SNAPSHOT</version>
+        <version>5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-http-servlet</artifactId>

--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-parent</artifactId>
-        <version>5.2.3.Final-SNAPSHOT</version>
+        <version>5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-http-vertx-backend</artifactId>

--- a/websocket/core/pom.xml
+++ b/websocket/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-websocket-parent</artifactId>
-        <version>5.2.3.Final-SNAPSHOT</version>
+        <version>5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-http-websocket-core</artifactId>

--- a/websocket/pom.xml
+++ b/websocket/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-parent</artifactId>
-        <version>5.2.3.Final-SNAPSHOT</version>
+        <version>5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-http-websocket-parent</artifactId>

--- a/websocket/servlet/pom.xml
+++ b/websocket/servlet/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-websocket-parent</artifactId>
-        <version>5.2.3.Final-SNAPSHOT</version>
+        <version>5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-http-websocket-servlet</artifactId>

--- a/websocket/vertx/pom.xml
+++ b/websocket/vertx/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-websocket-parent</artifactId>
-        <version>5.2.3.Final-SNAPSHOT</version>
+        <version>5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-http-websocket-vertx</artifactId>


### PR DESCRIPTION
This drops the .Final suffix.
Executed with `mvn versions:set -DnewVersion=5.2.3-SNAPSHOT`
