### PR TITLE
Make sure InMemorySessionManager stores session before notifying listeners

### DIFF
--- a/core/src/main/java/io/undertow/server/session/InMemorySessionManager.java
+++ b/core/src/main/java/io/undertow/server/session/InMemorySessionManager.java
@@ -184,8 +184,10 @@ public class InMemorySessionManager implements SessionManager, SessionManagerSta
         sessions.put(sessionID, session);
         config.setSessionId(serverExchange, session.getId());
         session.bumpTimeout();
-        sessionListeners.sessionCreated(session, serverExchange);
+        // Store an information about new session *before* notifying listeners
+        // Otherwise there might be a cycle with CDI observers for session context lifecycle
         serverExchange.putAttachment(NEW_SESSION, session);
+        sessionListeners.sessionCreated(session, serverExchange);
 
         if (statisticsEnabled) {
             createdSessionCount.incrementAndGet();


### PR DESCRIPTION
I came across this when re-visiting https://github.com/quarkusio/quarkus/issues/46363 and I believe this is the correct fix for it.

That being said, I am not sure what other parts of Quarkus (or user code?) might possibly rely on the current ordering of listener notification versus session storage.
@gsmet any idea what should I check? Obviously I tried the Undertow tests in Quarkus repo but that feels a little insufficient.

Also cc @mkouba as you were at least vaguely aware of the original issue :)