### PR TITLE
Fix automatic module generation

### DIFF
--- a/core/src/main/resources/META-INF/services/io.undertow.xnio.client.ClientProvider
+++ b/core/src/main/resources/META-INF/services/io.undertow.xnio.client.ClientProvider
@@ -1,5 +1,0 @@
-io.undertow.xnio.client.http.HttpClientProvider
-io.undertow.xnio.client.ajp.AjpClientProvider
-io.undertow.xnio.client.http2.Http2ClientProvider
-io.undertow.xnio.client.http2.Http2ClearClientProvider
-io.undertow.xnio.client.http2.Http2PriorKnowledgeClientProvider


### PR DESCRIPTION
Fix a problem generating an automatic module due to a stale service file. The commit which removed the service interface was d973a4254496c3f2ac30774916b24e281389524a.